### PR TITLE
Conda env variables fix

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -21,10 +21,13 @@ EOC
 
 cat << EOD >> ${PREFIX}/etc/conda/deactivate.d/env_vars.sh
 #!/usr/bin/env bash
+export PATH=:\${PATH}: # Wrap with colon to prevent special case
+export PATH=\${PATH//:\$WEST_BIN:} # Remove the Path
+export PATH=\${PATH#:} # Remove start colon
+export PATH=\${PATH%:} # Remove end colon
 unset WEST_ROOT
 unset WEST_BIN
 unset WEST_PYTHON
-export PATH=${PATH#${PREFIX}/${PKG_NAME}-${PKG_VERSION}/bin:}
 EOD
 
 # Clean up of previously set codes in activate.d

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -12,14 +12,14 @@ WEST_PYTHON=$WEST_PYTHON $WEST_PYTHON .westpa_gen.py
 chmod +x westpa.sh
 
 # Export WESTPA environment variables
-mkdir -p ${CONDA_PREFIX}/etc/conda/{activate,deactivate}.d
-touch ${CONDA_PREFIX}/etc/conda/{activate,deactivate}.d/env_vars.sh
-cat << EOC >> ${CONDA_PREFIX}/etc/conda/activate.d/env_vars.sh
+mkdir -p ${PREFIX}/etc/conda/{activate,deactivate}.d
+touch ${PREFIX}/etc/conda/{activate,deactivate}.d/env_vars.sh
+cat << EOC >> ${PREFIX}/etc/conda/activate.d/env_vars.sh
 #!/usr/bin/env bash
 . ${PREFIX}/${PKG_NAME}-${PKG_VERSION}/westpa.sh
 EOC
 
-cat << EOD >> ${CONDA_PREFIX}/etc/conda/deactivate.d/env_vars.sh
+cat << EOD >> ${PREFIX}/etc/conda/deactivate.d/env_vars.sh
 #!/usr/bin/env bash
 unset WEST_ROOT
 unset WEST_BIN

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   skip: True  # [win or py2k]
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "westpa" %}
 {% set version = "2020.05" %}
-{% set sha256 = "517f016d0aaafcd6b5a0c9da203fab8c7d4b72e3c15502406bcca38bffbabb63" %}
+{% set sha256 = "e93755babb0db4138f3a5da24f5a3a33885a655920352e803b5d84b1861a569f" %}
 
 package:
   name: {{ name|lower }}
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 1
+  number: 2
   skip: True  # [win or py2k]
 
 requirements:


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
Seems like my understanding of $CONDA_PREFIX, $PREFIX and conda-build was faulty (and as such previous testing was incomplete). This led to the previous PR (#25) actually breaking the auto-sourcing of westpa.sh when the environment is activated. 

Triple checked this one (with extra help testing) so this should fix everything.

@synapticarbors If you can check and approve this, that'll be great. Thanks, again!

<!--
Please add any other relevant info below:
-->
